### PR TITLE
Send an error when the host is not reachable.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
         options: {
           mocha: require('mocha'),
           reporter: 'spec',
-          timeout: 2000
+          timeout: 5000
         },
         src: ['test/*.js']
       }

--- a/lib/client.js
+++ b/lib/client.js
@@ -18,6 +18,7 @@
 /*jshint globalstrict: true*/
 
 var util = require('util');
+var request = require('request');
 var url = require('url');
 var events = require('events');
 var WebSocket = require('ws');
@@ -43,7 +44,7 @@ function Client(baseUrl, user, pass) {
   var self = this;
   events.EventEmitter.call(self);
 
-  // Store connection settings for prototype methods 
+  // Store connection settings for prototype methods
   var parsedUrl = url.parse(baseUrl);
   /**
    * Connection parts to an ARI instance.
@@ -73,7 +74,7 @@ function Client(baseUrl, user, pass) {
   self._instanceListeners = {};
 }
 
-// Make Client an Event Emitter 
+// Make Client an Event Emitter
 util.inherits(Client, events.EventEmitter);
 
 /**
@@ -103,16 +104,29 @@ Client.prototype._attachApi = function (
     )
   );
 
-  // Connect to API using swagger and attach resources on Client instance 
+  // Connect to API using swagger and attach resources on Client instance
   var ariUrl = util.format(
     '%s//%s/ari/api-docs/resources.json',
     self._connection.protocol,
     self._connection.host
   );
-  self._swagger = new swagger.SwaggerApi({
-    url: ariUrl,
-    success: swaggerLoaded,
-    failure: swaggerFailed
+
+  // check that the host is reachable
+  request(ariUrl, function (err) {
+    if (err && err.message === 'getaddrinfo ENOTFOUND') {
+      var error = new Error(err);
+      error.name = 'HostIsNotReachable';
+
+      if (_.isFunction(callback)) {
+        callback(error);
+      }
+    } else {
+      self._swagger = new swagger.SwaggerApi({
+        url: ariUrl,
+        success: swaggerLoaded,
+        failure: swaggerFailed
+      });
+    }
   });
 
   /**
@@ -125,10 +139,10 @@ Client.prototype._attachApi = function (
    */
   function swaggerLoaded () {
     if(self._swagger.ready === true) {
-      // Attach resources to client 
+      // Attach resources to client
       _.each(_.keys(self._swagger.apis), attachResource);
-      
-      // Attach resource creators to client 
+
+      // Attach resource creators to client
       _.each(_resources.knownTypes, attachResourceCreators);
 
       if (_.isFunction(callback)) {
@@ -187,7 +201,7 @@ Client.prototype._attachApi = function (
     var operations = self._swagger.apis[resource].operations;
     _.each(_.keys(operations), attachOperation);
 
-    // Attach operation to resource 
+    // Attach operation to resource
     function attachOperation (operation) {
       self[resource][operation] = callSwagger;
 
@@ -212,7 +226,7 @@ Client.prototype._attachApi = function (
        *  @param {Function} callback - callback invoked with swagger response
        */
       function callSwagger (/* args..., callback */) {
-        // Separate user callback from other args 
+        // Separate user callback from other args
         var args = _.toArray(arguments);
         var options = _.first(args);
         var userCallback = _.last(args);
@@ -221,22 +235,22 @@ Client.prototype._attachApi = function (
             _.isFunction(options) || _.isArray(options)) {
           options = {};
         } else {
-          // Swagger can alter options passed in 
+          // Swagger can alter options passed in
           options = _.clone(options);
           // convert body params for swagger
           options = _utils.parseBodyParams(params, options);
         }
 
         args.push(options);
-        // Inject response processing callback 
+        // Inject response processing callback
         args.push(processResponse);
-        // Inject error handling callback 
+        // Inject error handling callback
         args.push(swaggerError);
 
-        // Run operation against Swagger 
+        // Run operation against Swagger
         self._swagger.apis[resource][operation].apply(null, args);
 
-        // Handle error from Swagger 
+        // Handle error from Swagger
         function swaggerError (err) {
           if (err && err.data) {
             err = new Error(err.data.toString('utf-8'));
@@ -288,14 +302,14 @@ Client.prototype._attachApi = function (
 };
 
 /**
- *  Creates the web socket connection, subscribing to the given apps. 
+ *  Creates the web socket connection, subscribing to the given apps.
  *
  *  @memberof Client
  *  @method start
  */
 Client.prototype.start = function (apps) {
   var self = this;
-  var applications = (_.isArray(apps)) ? apps.join(',') : apps; 
+  var applications = (_.isArray(apps)) ? apps.join(',') : apps;
   var wsUrl = util.format(
     'ws://%s/ari/events?app=%s&api_key=%s:%s',
     self._connection.host,
@@ -331,7 +345,7 @@ Client.prototype.start = function (apps) {
     var resources = {};
     var instanceIds = [];
 
-    // Pass in any property that is a known type as an object 
+    // Pass in any property that is a known type as an object
     _.each(eventModel.properties, function (prop) {
       if (_.contains(_resources.knownTypes, prop.dataType) &&
           event[prop.name] !== undefined &&
@@ -380,7 +394,7 @@ Client.prototype.start = function (apps) {
     }
 
     self.emit(event.type, event, resources);
-    // If appropriate, emit instance specific events 
+    // If appropriate, emit instance specific events
     if (instanceIds.length > 0) {
       _.each(instanceIds, function (instanceId) {
         self.emit(
@@ -420,9 +434,9 @@ module.exports.connect = function (baseUrl, user, pass,
     /**
      *  @callback connectCallback
      *  @memberof module:ari-client
-     *  @param {Error} err - error object if any, null otherwise 
+     *  @param {Error} err - error object if any, null otherwise
      *  @param {Client} ari - ARI client instance
-     */  
+     */
     callback) {
 
   var client = new Client(baseUrl, user, pass);
@@ -435,4 +449,3 @@ module.exports.connect = function (baseUrl, user, pass,
     }
   });
 };
-

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,67 +1,263 @@
 {
   "name": "ari-client",
-  "version": "0.0.1",
+  "version": "0.1.7",
   "dependencies": {
     "node-uuid": {
       "version": "1.4.1",
-      "from": "node-uuid@",
+      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+    },
+    "request": {
+      "version": "2.53.0",
+      "from": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+      "dependencies": {
+        "bl": {
+          "version": "0.9.4",
+          "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "caseless": {
+          "version": "0.9.0",
+          "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+        },
+        "form-data": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            }
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.0",
+          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.0.9",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+          "dependencies": {
+            "mime-db": {
+              "version": "1.7.0",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+            }
+          }
+        },
+        "qs": {
+          "version": "2.3.3",
+          "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+        },
+        "tunnel-agent": {
+          "version": "0.4.0",
+          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+        },
+        "tough-cookie": {
+          "version": "0.12.1",
+          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            }
+          }
+        },
+        "http-signature": {
+          "version": "0.10.1",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.1.5",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+            },
+            "asn1": {
+              "version": "0.1.11",
+              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+            },
+            "ctype": {
+              "version": "0.5.3",
+              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+            }
+          }
+        },
+        "oauth-sign": {
+          "version": "0.6.0",
+          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+        },
+        "hawk": {
+          "version": "2.3.1",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+          "dependencies": {
+            "hoek": {
+              "version": "2.11.0",
+              "from": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
+            },
+            "boom": {
+              "version": "2.6.1",
+              "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
+            },
+            "cryptiles": {
+              "version": "2.0.4",
+              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+            }
+          }
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.4",
+          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "dependencies": {
+            "delayed-stream": {
+              "version": "0.0.5",
+              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+            }
+          }
+        },
+        "isstream": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
+        }
+      }
     },
     "swagger-client": {
       "version": "2.0.26",
-      "from": "swagger-client@^2.0.23",
+      "from": "https://registry.npmjs.org/swagger-client/-/swagger-client-2.0.26.tgz",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-2.0.26.tgz",
       "dependencies": {
         "shred": {
           "version": "0.8.10",
-          "from": "shred@0.8.10",
+          "from": "https://registry.npmjs.org/shred/-/shred-0.8.10.tgz",
+          "resolved": "https://registry.npmjs.org/shred/-/shred-0.8.10.tgz",
           "dependencies": {
             "sprintf": {
               "version": "0.1.1",
-              "from": "sprintf@0.1.1"
+              "from": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.1.tgz"
             },
             "ax": {
               "version": "0.1.8",
-              "from": "ax@0.1.8"
+              "from": "https://registry.npmjs.org/ax/-/ax-0.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/ax/-/ax-0.1.8.tgz"
             },
             "cookiejar": {
               "version": "1.3.1",
-              "from": "cookiejar@1.3.1"
+              "from": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.1.tgz"
             },
             "iconv-lite": {
               "version": "0.2.11",
-              "from": "iconv-lite@>= 0.1.2"
+              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
             }
           }
         },
         "btoa": {
           "version": "1.1.1",
-          "from": "btoa@1.1.1"
+          "from": "https://registry.npmjs.org/btoa/-/btoa-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.1.1.tgz"
         }
       }
     },
     "underscore": {
       "version": "1.6.0",
-      "from": "underscore@^1.6.0"
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
     },
     "ws": {
       "version": "0.4.31",
-      "from": "ws@^0.4.31",
+      "from": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
       "dependencies": {
         "commander": {
           "version": "0.6.1",
-          "from": "commander@~0.6.1"
+          "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
         },
         "nan": {
           "version": "0.3.2",
-          "from": "nan@~0.3.0"
+          "from": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
         },
         "tinycolor": {
           "version": "0.0.1",
-          "from": "tinycolor@0.x"
+          "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
         },
         "options": {
           "version": "0.0.5",
-          "from": "options@>=0.0.5"
+          "from": "https://registry.npmjs.org/options/-/options-0.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/options/-/options-0.0.5.tgz"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ari-client",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "JavaScript client for Asterisk REST Interface.",
   "homepage": "https://github.com/asterisk/node-ari-client",
   "keywords": [
@@ -22,10 +22,11 @@
   "license": "Apache-2.0",
   "author": "Samuel Fortier-Galarneau",
   "dependencies": {
+    "node-uuid": "^1.4.1",
+    "request": "^2.53.0",
     "swagger-client": "^2.0.26",
-    "ws": "^0.4.31",
     "underscore": "^1.6.0",
-    "node-uuid": "^1.4.1"
+    "ws": "^0.4.31"
   },
   "engines": {
     "node": ">=0.10.0"
@@ -41,7 +42,6 @@
     "istanbul": "^0.3.2",
     "mocha": "^1.17.1",
     "moment": "^2.6.0",
-    "mustache": "^0.8.1",
-    "request": "^2.34.0"
+    "mustache": "^0.8.1"
   }
 }

--- a/test/client.js
+++ b/test/client.js
@@ -148,6 +148,15 @@ describe('client', function () {
     client.connect(url, user, pass, done);
   });
 
+  it('should send an error if host is not reachable', function(done) {
+    url = 'http://notthere:8088';
+    client.connect(url, user, pass, function(err, newClient) {
+      if (err && err.name === 'HostIsNotReachable') {
+        done();
+      }
+    });
+  });
+
   it('should have all resources', function (done) {
     var candidates = _.keys(ari);
     var expected = [
@@ -191,7 +200,7 @@ describe('client', function () {
     _.each(operations, function (value, key) {
       it(util.format('%s should have all operations', key), function (done) {
         var candidates = _.keys(ari[key]);
-        var expected = value; 
+        var expected = value;
 
         _.each(expected, function (resource) {
           assert(_.contains(candidates, resource));
@@ -232,7 +241,7 @@ describe('client', function () {
       ari.bridges.get({bridgeId: '1'}, function (err, bridge) {
         assert(bridge === undefined);
         assert(err.message.match('Bridge not found'));
-        
+
         done();
       });
     });
@@ -495,4 +504,3 @@ describe('client', function () {
 
   });
 });
-


### PR DESCRIPTION
Currently, swagger reports errors once a connection has been established (such as an authentication failure), but not before. If a user attempts to connect to a host that does not exist, ari-client does not report that an error occured. This PR fixes this by first connecting to the host using request. If the host is not reachable, the error is reported. Otherwise, the swagger connection is established as it is today.

A test is also included to ensure that connecting to a bad host will result in the expected error being passed to the callback passed in to the client._attachApi method.
