### PR TITLE
The client will now attempt to reconnect to a dropped WebSocket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1171,6 +1171,14 @@ ARI client failed to load.
 function (err) {}
 ```
 
+#### WebSocketMaxRetries
+
+Client will no longer attempt to reconnect to the WebSocket for the current application(s).
+
+```JavaScript
+function (err) {}
+```
+
 #### ApplicationReplaced
 
 Notification that another WebSocket has taken over for an application.

--- a/dev/README.mustache
+++ b/dev/README.mustache
@@ -112,6 +112,14 @@ ARI client failed to load.
 function (err) {}
 ```
 
+#### WebSocketMaxRetries
+
+Client will no longer attempt to reconnect to the WebSocket for the current application(s).
+
+```JavaScript
+function (err) {}
+```
+
 {{{events}}}
 
 # Examples

--- a/lib/client.js
+++ b/lib/client.js
@@ -23,6 +23,8 @@ var events = require('events');
 var WebSocket = require('ws');
 var swagger = require('swagger-client');
 var _ = require('underscore');
+var backoff = require('backoff-func');
+
 var _resources = require('./resources.js');
 var _utils = require('./utils.js');
 
@@ -43,7 +45,7 @@ function Client(baseUrl, user, pass) {
   var self = this;
   events.EventEmitter.call(self);
 
-  // Store connection settings for prototype methods 
+  // Store connection settings for prototype methods
   var parsedUrl = url.parse(baseUrl);
   /**
    * Connection parts to an ARI instance.
@@ -73,7 +75,7 @@ function Client(baseUrl, user, pass) {
   self._instanceListeners = {};
 }
 
-// Make Client an Event Emitter 
+// Make Client an Event Emitter
 util.inherits(Client, events.EventEmitter);
 
 /**
@@ -103,7 +105,7 @@ Client.prototype._attachApi = function (
     )
   );
 
-  // Connect to API using swagger and attach resources on Client instance 
+  // Connect to API using swagger and attach resources on Client instance
   var ariUrl = util.format(
     '%s//%s/ari/api-docs/resources.json',
     self._connection.protocol,
@@ -125,10 +127,10 @@ Client.prototype._attachApi = function (
    */
   function swaggerLoaded () {
     if(self._swagger.ready === true) {
-      // Attach resources to client 
+      // Attach resources to client
       _.each(_.keys(self._swagger.apis), attachResource);
-      
-      // Attach resource creators to client 
+
+      // Attach resource creators to client
       _.each(_resources.knownTypes, attachResourceCreators);
 
       if (_.isFunction(callback)) {
@@ -187,7 +189,7 @@ Client.prototype._attachApi = function (
     var operations = self._swagger.apis[resource].operations;
     _.each(_.keys(operations), attachOperation);
 
-    // Attach operation to resource 
+    // Attach operation to resource
     function attachOperation (operation) {
       self[resource][operation] = callSwagger;
 
@@ -212,7 +214,7 @@ Client.prototype._attachApi = function (
        *  @param {Function} callback - callback invoked with swagger response
        */
       function callSwagger (/* args..., callback */) {
-        // Separate user callback from other args 
+        // Separate user callback from other args
         var args = _.toArray(arguments);
         var options = _.first(args);
         var userCallback = _.last(args);
@@ -221,22 +223,22 @@ Client.prototype._attachApi = function (
             _.isFunction(options) || _.isArray(options)) {
           options = {};
         } else {
-          // Swagger can alter options passed in 
+          // Swagger can alter options passed in
           options = _.clone(options);
           // convert body params for swagger
           options = _utils.parseBodyParams(params, options);
         }
 
         args.push(options);
-        // Inject response processing callback 
+        // Inject response processing callback
         args.push(processResponse);
-        // Inject error handling callback 
+        // Inject error handling callback
         args.push(swaggerError);
 
-        // Run operation against Swagger 
+        // Run operation against Swagger
         self._swagger.apis[resource][operation].apply(null, args);
 
-        // Handle error from Swagger 
+        // Handle error from Swagger
         function swaggerError (err) {
           if (err && err.data) {
             err = new Error(err.data.toString('utf-8'));
@@ -288,14 +290,18 @@ Client.prototype._attachApi = function (
 };
 
 /**
- *  Creates the web socket connection, subscribing to the given apps. 
+ *  Creates the web socket connection, subscribing to the given apps.
  *
  *  @memberof Client
  *  @method start
  */
 Client.prototype.start = function (apps) {
   var self = this;
-  var applications = (_.isArray(apps)) ? apps.join(',') : apps; 
+
+  // are we currently processing a WebSocket error?
+  var processingError = false;
+
+  var applications = (_.isArray(apps)) ? apps.join(',') : apps;
   var wsUrl = util.format(
     'ws://%s/ari/events?app=%s&api_key=%s:%s',
     self._connection.host,
@@ -303,16 +309,32 @@ Client.prototype.start = function (apps) {
     self._connection.user,
     self._connection.pass
   );
-  self._ws = new WebSocket(wsUrl);
 
-  self._ws.on('open', function () { });
-  self._ws.on('message', processMessage);
-  self._ws.on('close', function () { });
+  var retry = backoff.create({
+    delay: 100
+  });
+
+  connect();
+
+  /**
+   *  Connects to the application via WebSocket.
+   *
+   *  @method connect
+   *  @memberof module:ari-client~Client~start
+   *  @private
+   */
+  function connect () {
+    self._ws = new WebSocket(wsUrl);
+
+    self._ws.on('message', processMessage);
+    self._ws.on('open', processOpen);
+    self._ws.on('close', processClose);
+    self._ws.on('error', processError);
+  }
 
   /**
    *  Process message received by web socket and emit event.
    *
-   *  @callback clientStartCallback
    *  @method processMessage
    *  @memberof module:ari-client~Client~start
    *  @private
@@ -331,7 +353,7 @@ Client.prototype.start = function (apps) {
     var resources = {};
     var instanceIds = [];
 
-    // Pass in any property that is a known type as an object 
+    // Pass in any property that is a known type as an object
     _.each(eventModel.properties, function (prop) {
       if (_.contains(_resources.knownTypes, prop.dataType) &&
           event[prop.name] !== undefined &&
@@ -380,7 +402,7 @@ Client.prototype.start = function (apps) {
     }
 
     self.emit(event.type, event, resources);
-    // If appropriate, emit instance specific events 
+    // If appropriate, emit instance specific events
     if (instanceIds.length > 0) {
       _.each(instanceIds, function (instanceId) {
         self.emit(
@@ -389,6 +411,75 @@ Client.prototype.start = function (apps) {
           resources
         );
       });
+    }
+  }
+
+  /**
+   *  Process open event.
+   *
+   *  @method processOpen
+   *  @memberof module:ari-client~Client~start
+   *  @private
+   */
+  function processOpen () {
+    processingError = false;
+  }
+
+  /**
+   *  Process close event. Attempt to reconnect to web socket with a back off
+   *  to ensure we do not flood the server.
+   *
+   *  @method processClose
+   *  @memberof module:ari-client~Client~start
+   *  @private
+   *  @param {Number} reason - reason code for disconnect
+   *  @param {String} description - reason text for disconnect
+   */
+  function processClose (reason, description) {
+    // was connection closed on purpose?
+    if (self._wsClosed) {
+      self._wsClosed = false;
+
+      return;
+    }
+
+    if (!processingError) {
+      reconnect();
+    }
+  }
+
+  /**
+   *  Process error event.
+   *
+   *  @method processError
+   *  @memberof module:ari-client~Client~start
+   *  @private
+   *  @param {Error} err - error object
+   */
+  function processError (err) {
+    // was connection closed on purpose?
+    if (self._wsClosed) {
+      return;
+    }
+
+    processingError = true;
+
+    reconnect(err);
+  }
+
+  /**
+   *  Attempts to reconnect to the WebSocket using a backoff function.
+   *
+   *  @method reconnect
+   *  @memberof module:ari-client~Client~start
+   *  @private
+   *  @param {Error} err - error object
+   */
+  function reconnect(err) {
+    var scheduled = retry(connect);
+
+    if (!scheduled) {
+      self.emit('WebSocketMaxRetries', err);
     }
   }
 };
@@ -401,7 +492,9 @@ Client.prototype.start = function (apps) {
  */
 Client.prototype.stop = function () {
   var self = this;
+
   self._ws.close();
+  self._wsClosed = true;
 };
 
 /**
@@ -420,9 +513,9 @@ module.exports.connect = function (baseUrl, user, pass,
     /**
      *  @callback connectCallback
      *  @memberof module:ari-client
-     *  @param {Error} err - error object if any, null otherwise 
+     *  @param {Error} err - error object if any, null otherwise
      *  @param {Client} ari - ARI client instance
-     */  
+     */
     callback) {
 
   var client = new Client(baseUrl, user, pass);
@@ -435,4 +528,3 @@ module.exports.connect = function (baseUrl, user, pass,
     }
   });
 };
-

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,67 +1,84 @@
 {
   "name": "ari-client",
-  "version": "0.0.1",
+  "version": "0.1.6",
   "dependencies": {
+    "backoff-func": {
+      "version": "0.1.1",
+      "from": "backoff-func@*"
+    },
     "node-uuid": {
       "version": "1.4.1",
-      "from": "node-uuid@",
+      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
     },
     "swagger-client": {
       "version": "2.0.26",
-      "from": "swagger-client@^2.0.23",
+      "from": "swagger-client@2.0.26",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-2.0.26.tgz",
       "dependencies": {
         "shred": {
           "version": "0.8.10",
           "from": "shred@0.8.10",
+          "resolved": "https://registry.npmjs.org/shred/-/shred-0.8.10.tgz",
           "dependencies": {
             "sprintf": {
               "version": "0.1.1",
-              "from": "sprintf@0.1.1"
+              "from": "sprintf@0.1.1",
+              "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.1.tgz"
             },
             "ax": {
               "version": "0.1.8",
-              "from": "ax@0.1.8"
+              "from": "ax@0.1.8",
+              "resolved": "https://registry.npmjs.org/ax/-/ax-0.1.8.tgz"
             },
             "cookiejar": {
               "version": "1.3.1",
-              "from": "cookiejar@1.3.1"
+              "from": "cookiejar@1.3.1",
+              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.1.tgz"
             },
             "iconv-lite": {
               "version": "0.2.11",
-              "from": "iconv-lite@>= 0.1.2"
+              "from": "iconv-lite@0.2.11",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
             }
           }
         },
         "btoa": {
           "version": "1.1.1",
-          "from": "btoa@1.1.1"
+          "from": "btoa@1.1.1",
+          "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.1.1.tgz"
         }
       }
     },
     "underscore": {
       "version": "1.6.0",
-      "from": "underscore@^1.6.0"
+      "from": "underscore@1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
     },
     "ws": {
       "version": "0.4.31",
-      "from": "ws@^0.4.31",
+      "from": "ws@0.4.31",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
       "dependencies": {
         "commander": {
           "version": "0.6.1",
-          "from": "commander@~0.6.1"
+          "from": "commander@0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
         },
         "nan": {
           "version": "0.3.2",
-          "from": "nan@~0.3.0"
+          "from": "nan@0.3.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
         },
         "tinycolor": {
           "version": "0.0.1",
-          "from": "tinycolor@0.x"
+          "from": "tinycolor@0.0.1",
+          "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
         },
         "options": {
           "version": "0.0.5",
-          "from": "options@>=0.0.5"
+          "from": "options@0.0.5",
+          "resolved": "https://registry.npmjs.org/options/-/options-0.0.5.tgz"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
   "license": "Apache-2.0",
   "author": "Samuel Fortier-Galarneau",
   "dependencies": {
+    "backoff-func": "^0.1.1",
+    "node-uuid": "^1.4.1",
     "swagger-client": "^2.0.26",
-    "ws": "^0.4.31",
     "underscore": "^1.6.0",
-    "node-uuid": "^1.4.1"
+    "ws": "^0.4.31"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -34,9 +34,7 @@ function createWebSocketServer (httpserver) {
   var server = new ws.Server({server: httpserver});
   var socket = null;
 
-  server.on('connection', function (websocket) {
-    socket = websocket;
-  });
+  server.on('connection', processConnection);
 
   /**
    *  Web socket server with a send method that will send a message to a
@@ -47,12 +45,38 @@ function createWebSocketServer (httpserver) {
    *  @property {Function} send - send a message to the listening socket
    */
   return {
+    /**
+     *  Sends the json message to the currently connected socket.
+     *
+     *  @param {Object} msg - the json message to send
+     */
     send: function (msg) {
       if (socket) {
         socket.send(JSON.stringify(msg));
       }
+    },
+
+    /**
+     *  Disconnects the server and reconnects.
+     *
+     *  This is intended to test client auto-reconnect.
+     */
+    reconnect: function() {
+      server.close(function() {
+        server = new ws.Server({server: httpserver});
+        server.on('connection', processConnection);
+      });
     }
   };
+
+  /**
+   *  Store the incoming websocket for future use.
+   *
+   *  @param {WebSocket} socket - socket for the last connection
+   */
+  function processConnection(websocket) {
+    socket = websocket;
+  }
 }
 
 /**
@@ -172,7 +196,7 @@ function mockClient (callback) {
  *  @memberof module:tests-helpers
  *  @private
  *  @param {string} filename - the name of the fixture
- *  @returns {string} the string representation of the json fixture 
+ *  @returns {string} the string representation of the json fixture
  */
 function readJsonFixture (filename) {
   // remove the last newline if it exists
@@ -205,4 +229,3 @@ function getJsonHeaders (json) {
 module.exports.mockClient = mockClient;
 module.exports.getJsonHeaders = getJsonHeaders;
 module.exports.createWebSocketServer = createWebSocketServer;
-


### PR DESCRIPTION
If a WebSocket is dropped for a reason other than a user stopping an ARI application, the client will attempt to reconnect to the WebSocket using an exponential backoff.

The initial reconnect will be attempted after 100 milliseconds. After that, each reconnect occurs by multiplying the previous delay by a factor of 2. If 10 attempts are unsuccessful, the client will emit an 'WebSocketMaxRetries' event and stop attempting to reconnect.