### PR TITLE
Add support for the 'Asterisk' resource

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -23,6 +23,7 @@ var _utils = require('./utils.js');
 // List of known resources to instantiate as first class object 
 var knownTypes = [
   'Application',
+  'Asterisk',
   'Channel',
   'Bridge',
   'DeviceState',
@@ -260,6 +261,39 @@ Application.prototype._param = 'applicationName';
  *  @memberof module:resources~Application
  */
 Application.prototype._resource = 'applications';
+
+/**
+ *  Asterisk object for asterisk API responses.
+ *
+ *  @class Asterisk
+ *  @constructor
+ *  @extends Resource
+ *  @param {Client} client - ARI client instance
+ *  @param {Object} objValues - ownProperties to copy to the instance
+ */
+function Asterisk (client, objValues) {
+  var self = this;
+  Resource.call(self, client, undefined, objValues);
+}
+
+util.inherits(Asterisk, Resource);
+
+/**
+ * The name of the identifier field used when passing as parameter.
+ *
+ * @member {string} _param
+ * @memberof module:resources~Asterisk
+ */
+Asterisk.prototype._param = '';
+
+/**
+ *  The name of this resource.
+ *
+ *  @member {string} _resource
+ *  @memberof module:resources~Application
+ */
+Asterisk.prototype._resource = 'asterisk';
+
 
 /**
  *  Bridge object for bridge API responses.
@@ -973,6 +1007,22 @@ module.exports.Application = function (client, id, objValues) {
   attachOperations.call(application);
   return application;
 };
+
+/**
+ * Creates a new Asterisk resource.
+ *
+ * @memberof module:resources
+ * @method Asterisk
+ * @param {Client} client - ARI client instance
+ * @param {Object} objValues - ownProperties to copy to instance
+ * @returns {module:resources~Asterisk} asterisk resource
+ */
+module.exports.Asterisk = function (client, objValues) {
+  var asterisk = new Asterisk(client, objValues);
+  attachOperations.call(asterisk);
+  return asterisk;
+};
+
 
 /**
  *  Creates a new Bridge instance.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,6 +40,8 @@ function parseBodyParams(params, swaggerOptions) {
       // wrap the key/value pairs
       if (bodyParam.name === 'variables' && !options.variables.variables) {
         jsonBody = {variables: jsonBody};
+      } else if (bodyParam.name === 'fields' && !options.fields.fields) {
+	jsonBody = {fields: jsonBody};
       }
       options.body = JSON.stringify(jsonBody);
       delete options[bodyParam.name];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ari-client",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "JavaScript client for Asterisk REST Interface.",
   "homepage": "https://github.com/asterisk/node-ari-client",
   "keywords": [


### PR DESCRIPTION
This patch adds support for the 'Asterisk' resource. This includes the
existing Asterisk resource operations, as well as the proposed push
configuration operations.

Note that since the 'Asterisk' resource does not have an identifier and
will always have a single 'instance' of itself, it does not need an ID,
nor does it really make use of the _params field.