### PR TITLE
Add support for the 'Asterisk' resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,21 @@ ari.applications.unsubscribe(
 
 #### asterisk
 
+##### deleteObject
+
+Delete a dynamic configuration object.
+
+```javascript
+ari.asterisk.deleteObject(
+  {configClass: val, id: val, objectType: val},
+  function (err) {}
+);
+```
+###### Available Parameters
+- configClass (string) - The configuration class containing dynamic configuration objects.
+- id (string) - The unique identifier of the object to delete.
+- objectType (string) - The type of configuration object to delete.
+
 ##### getGlobalVar
 
 Get the value of a global variable.
@@ -176,6 +191,21 @@ ari.asterisk.getInfo(
 ###### Available Parameters
 - only (string) - Filter information returned
 
+##### getObject
+
+Retrieve a dynamic configuration object.
+
+```javascript
+ari.asterisk.getObject(
+  {configClass: val, id: val, objectType: val},
+  function (err, configtuples) {}
+);
+```
+###### Available Parameters
+- configClass (string) - The configuration class containing dynamic configuration objects.
+- id (string) - The unique identifier of the object to retrieve.
+- objectType (string) - The type of configuration object to retrieve.
+
 ##### setGlobalVar
 
 Set the value of a global variable.
@@ -189,6 +219,22 @@ ari.asterisk.setGlobalVar(
 ###### Available Parameters
 - value (string) - The value to set the variable to
 - variable (string) - The variable to set
+
+##### updateObject
+
+Create or update a dynamic configuration object.
+
+```javascript
+ari.asterisk.updateObject(
+  {configClass: val, id: val, objectType: val},
+  function (err, configtuples) {}
+);
+```
+###### Available Parameters
+- configClass (string) - The configuration class containing dynamic configuration objects.
+- fields (containers) - The body object should have a value that is a list of ConfigTuples, which provide the fields to update. Ex. [ { "attribute": "directmedia", "value": "false" } ]
+- id (string) - The unique identifier of the object to create or update.
+- objectType (string) - The type of configuration object to create or update.
 
 #### bridges
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -23,6 +23,7 @@ var _utils = require('./utils.js');
 // List of known resources to instantiate as first class object 
 var knownTypes = [
   'Application',
+  'Asterisk',
   'Channel',
   'Bridge',
   'DeviceState',
@@ -260,6 +261,39 @@ Application.prototype._param = 'applicationName';
  *  @memberof module:resources~Application
  */
 Application.prototype._resource = 'applications';
+
+/**
+ *  Asterisk object for asterisk API responses.
+ *
+ *  @class Asterisk
+ *  @constructor
+ *  @extends Resource
+ *  @param {Client} client - ARI client instance
+ *  @param {Object} objValues - ownProperties to copy to the instance
+ */
+function Asterisk (client, objValues) {
+  var self = this;
+  Resource.call(self, client, undefined, objValues);
+}
+
+util.inherits(Asterisk, Resource);
+
+/**
+ * The name of the identifier field used when passing as parameter.
+ *
+ * @member {string} _param
+ * @memberof module:resources~Asterisk
+ */
+Asterisk.prototype._param = '';
+
+/**
+ *  The name of this resource.
+ *
+ *  @member {string} _resource
+ *  @memberof module:resources~Application
+ */
+Asterisk.prototype._resource = 'asterisk';
+
 
 /**
  *  Bridge object for bridge API responses.
@@ -973,6 +1007,22 @@ module.exports.Application = function (client, id, objValues) {
   attachOperations.call(application);
   return application;
 };
+
+/**
+ * Creates a new Asterisk resource.
+ *
+ * @memberof module:resources
+ * @method Asterisk
+ * @param {Client} client - ARI client instance
+ * @param {Object} objValues - ownProperties to copy to instance
+ * @returns {module:resources~Asterisk} asterisk resource
+ */
+module.exports.Asterisk = function (client, objValues) {
+  var asterisk = new Asterisk(client, objValues);
+  attachOperations.call(asterisk);
+  return asterisk;
+};
+
 
 /**
  *  Creates a new Bridge instance.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,6 +40,8 @@ function parseBodyParams(params, swaggerOptions) {
       // wrap the key/value pairs
       if (bodyParam.name === 'variables' && !options.variables.variables) {
         jsonBody = {variables: jsonBody};
+      } else if (bodyParam.name === 'fields' && !options.fields.fields) {
+	jsonBody = {fields: jsonBody};
       }
       options.body = JSON.stringify(jsonBody);
       delete options[bodyParam.name];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ari-client",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "JavaScript client for Asterisk REST Interface.",
   "homepage": "https://github.com/asterisk/node-ari-client",
   "keywords": [

--- a/test/fixtures/asterisk.json
+++ b/test/fixtures/asterisk.json
@@ -8,6 +8,146 @@
   "resourcePath": "/api-docs/asterisk.{format}",
   "apis": [
     {
+      "path": "/asterisk/config/dynamic/{configClass}/{objectType}/{id}",
+      "description": "Asterisk dynamic configuration",
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "summary": "Retrieve a dynamic configuration object.",
+          "nickname": "getObject",
+          "responseClass": "List[ConfigTuple]",
+          "parameters": [
+            {
+              "name": "configClass",
+              "description": "The configuration class containing dynamic configuration objects.",
+              "paramType": "path",
+              "required": true,
+              "allowMultiple": false,
+              "dataType": "string"
+            },
+            {
+              "name": "objectType",
+              "description": "The type of configuration object to retrieve.",
+              "paramType": "path",
+              "required": true,
+              "allowMultiple": false,
+              "dataType": "string"
+            },
+            {
+              "name": "id",
+              "description": "The unique identifier of the object to retrieve.",
+              "paramType": "path",
+              "required": true,
+              "allowMultiple": false,
+              "dataType": "string"
+            }
+          ],
+          "errorResponses": [
+            {
+              "code": 404,
+              "reason": "{configClass|objectType|id} not found"
+            }
+          ]
+        },
+        {
+          "httpMethod": "PUT",
+          "summary": "Create or update a dynamic configuration object.",
+          "nickname": "updateObject",
+          "responseClass": "List[ConfigTuple]",
+          "parameters": [
+            {
+              "name": "configClass",
+              "description": "The configuration class containing dynamic configuration objects.",
+              "paramType": "path",
+              "required": true,
+              "allowMultiple": false,
+              "dataType": "string"
+            },
+            {
+              "name": "objectType",
+              "description": "The type of configuration object to create or update.",
+              "paramType": "path",
+              "required": true,
+              "allowMultiple": false,
+              "dataType": "string"
+            },
+            {
+              "name": "id",
+              "description": "The unique identifier of the object to create or update.",
+              "paramType": "path",
+              "required": true,
+              "allowMultiple": false,
+              "dataType": "string"
+            },
+            {
+              "name": "fields",
+              "description": "The body object should have a value that is a list of ConfigTuples, which provide the fields to update. Ex. [ { \"attribute\": \"directmedia\", \"value\": \"false\" } ]",
+              "paramType": "body",
+              "required": false,
+              "dataType": "containers",
+              "allowMultiple": false
+            }
+          ],
+          "errorResponses": [
+            {
+              "code": 400,
+              "reason": "Bad request body"
+            },
+            {
+              "code": 403,
+              "reason": "Could not create or update object"
+            },
+            {
+              "code": 404,
+              "reason": "{configClass|objectType} not found"
+            }
+          ]
+        },
+        {
+          "httpMethod": "DELETE",
+          "summary": "Delete a dynamic configuration object.",
+          "nickname": "deleteObject",
+          "responseClass": "void",
+          "parameters": [
+            {
+              "name": "configClass",
+              "description": "The configuration class containing dynamic configuration objects.",
+              "paramType": "path",
+              "required": true,
+              "allowMultiple": false,
+              "dataType": "string"
+            },
+            {
+              "name": "objectType",
+              "description": "The type of configuration object to delete.",
+              "paramType": "path",
+              "required": true,
+              "allowMultiple": false,
+              "dataType": "string"
+            },
+            {
+              "name": "id",
+              "description": "The unique identifier of the object to delete.",
+              "paramType": "path",
+              "required": true,
+              "allowMultiple": false,
+              "dataType": "string"
+            }
+          ],
+          "errorResponses": [
+            {
+              "code": 403,
+              "reason": "Could not delete object"
+            },
+            {
+              "code": 404,
+              "reason": "{configClass|objectType|id} not found"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": "/asterisk/info",
       "description": "Asterisk system information (similar to core show settings)",
       "operations": [
@@ -252,6 +392,22 @@
           "required": true,
           "type": "string",
           "description": "The value of the variable requested"
+        }
+      }
+    },
+    "ConfigTuple": {
+      "id": "ConfigTuple",
+      "description": "A key/value pair that makes up part of a configuration object.",
+      "properties": {
+        "attribute": {
+          "required": true,
+          "type": "string",
+          "description": "A configuration object attribute."
+        },
+        "value": {
+          "required": true,
+          "type": "string",
+          "description": "The value for the attribute."
         }
       }
     }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -146,6 +146,14 @@ function mockClient (callback) {
       .reply(200, body, headers);
 
     // setup applications URI
+    body = readJsonFixture('asterisk');
+    headers = getJsonHeaders(body);
+    hockServer
+      .get('/ari/api-docs/asterisk.json')
+      .any()
+      .reply(200, body, headers);
+
+    // setup applications URI
     body = readJsonFixture('applications');
     headers = getJsonHeaders(body);
     hockServer


### PR DESCRIPTION
This patch adds support for the 'Asterisk' resource. This includes the
existing Asterisk resource operations, as well as the proposed push
configuration operations.

Note that since the 'Asterisk' resource does not have an identifier and
will always have a single 'instance' of itself, it does not need an ID,
nor does it really make use of the _params field.