### PR TITLE
lib/client: Make ari.start() return a Promise that resolves on WS open

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -297,104 +297,114 @@ Client.prototype._attachApi = function () {
  *  @memberof Client
  *  @method start
  */
-Client.prototype.start = function (apps) {
+Client.prototype.start = function (apps, callback) {
   var self = this;
-  var applications = (_.isArray(apps)) ? apps.join(',') : apps;
-  var wsUrl = util.format(
-    'ws://%s/ari/events?app=%s&api_key=%s:%s',
-    self._connection.host,
-    applications,
-    self._connection.user,
-    self._connection.pass
-  );
-  self._ws = new WebSocket(wsUrl);
 
-  self._ws.on('open', function () { });
-  self._ws.on('message', processMessage);
-  self._ws.on('close', function () { });
+  return new Promise(function(resolve, reject) {
 
-  /**
-   *  Process message received by web socket and emit event.
-   *
-   *  @callback clientStartCallback
-   *  @method processMessage
-   *  @memberof module:ari-client~Client~start
-   *  @private
-   *  @param {Object} msg - the web socket message
-   *  @param {Object} flags - web socket control flags
-   */
-  function processMessage (msg, flags) {
-    var event = {};
-    if (msg) {
-      event = JSON.parse(msg);
-    }
-    var eventModels = self._swagger.apis.events.models;
-    var eventModel = _.find(eventModels, function (item, key) {
-      return key === event.type;
+    var applications = (_.isArray(apps)) ? apps.join(',') : apps;
+    var wsUrl = util.format(
+      'ws://%s/ari/events?app=%s&api_key=%s:%s',
+      self._connection.host,
+      applications,
+      self._connection.user,
+      self._connection.pass
+    );
+
+    self._ws = new WebSocket(wsUrl);
+
+    self._ws.on('open', function () {
+      resolve();
     });
-    var resources = {};
-    var instanceIds = [];
+    self._ws.on('error', function (err) {
+      reject(err);
+    });
+    self._ws.on('message', processMessage);
+    self._ws.on('close', function () { });
 
-    // Pass in any property that is a known type as an object
-    _.each(eventModel.properties, function (prop) {
-      if (_.contains(_resources.knownTypes, prop.dataType) &&
-          event[prop.name] !== undefined &&
-          _resources[prop.dataType] !== undefined) {
-
-        var instance = _resources[prop.dataType](
-          self,
-          event[prop.name]
-        );
-        resources[prop.name] = instance;
-
-        // Keep track of which instance specific events we should
-        // emit
-        var listeners = self._instanceListeners[event.type];
-        var instanceId = instance._id().toString();
-
-        if (listeners) {
-          var updatedListeners = [];
-
-          _.each(listeners, function(listener) {
-            if (listener.id === instanceId) {
-              // make sure we do not duplicate events for a given instance
-              if (!_.contains(instanceIds, instanceId)) {
-                instanceIds.push(instanceId);
-              }
-
-              // remove listeners that should only be invoked once
-              if (!listener.once) {
-                updatedListeners.push(listener);
-              }
-            } else {
-              updatedListeners.push(listener);
-            }
-          });
-
-          self._instanceListeners[event.type] = updatedListeners;
-        }
+    /**
+     *  Process message received by web socket and emit event.
+     *
+     *  @callback clientStartCallback
+     *  @method processMessage
+     *  @memberof module:ari-client~Client~start
+     *  @private
+     *  @param {Object} msg - the web socket message
+     *  @param {Object} flags - web socket control flags
+     */
+    function processMessage (msg, flags) {
+      var event = {};
+      if (msg) {
+        event = JSON.parse(msg);
       }
-    });
-
-    var promoted = _.keys(resources).length;
-    if (promoted === 1) {
-      resources = resources[_.keys(resources)[0]];
-    } else if (promoted === 0) {
-      resources = undefined;
-    }
-
-    self.emit(event.type, event, resources);
-    // If appropriate, emit instance specific events
-    if (instanceIds.length > 0) {
-      _.each(instanceIds, function (instanceId) {
-        self.emit(
-          util.format('%s-%s', event.type, instanceId),
-          event,
-          resources
-        );
+      var eventModels = self._swagger.apis.events.models;
+      var eventModel = _.find(eventModels, function (item, key) {
+        return key === event.type;
       });
+      var resources = {};
+      var instanceIds = [];
+
+      // Pass in any property that is a known type as an object
+      _.each(eventModel.properties, function (prop) {
+        if (_.contains(_resources.knownTypes, prop.dataType) &&
+            event[prop.name] !== undefined &&
+            _resources[prop.dataType] !== undefined) {
+
+          var instance = _resources[prop.dataType](
+            self,
+            event[prop.name]
+          );
+          resources[prop.name] = instance;
+
+          // Keep track of which instance specific events we should
+          // emit
+          var listeners = self._instanceListeners[event.type];
+          var instanceId = instance._id().toString();
+
+          if (listeners) {
+            var updatedListeners = [];
+
+            _.each(listeners, function(listener) {
+              if (listener.id === instanceId) {
+                // make sure we do not duplicate events for a given instance
+                if (!_.contains(instanceIds, instanceId)) {
+                  instanceIds.push(instanceId);
+                }
+
+                // remove listeners that should only be invoked once
+                if (!listener.once) {
+                  updatedListeners.push(listener);
+                }
+              } else {
+               updatedListeners.push(listener);
+              }
+            });
+
+            self._instanceListeners[event.type] = updatedListeners;
+          }
+        }
+      });
+
+      var promoted = _.keys(resources).length;
+      if (promoted === 1) {
+        resources = resources[_.keys(resources)[0]];
+      } else if (promoted === 0) {
+        resources = undefined;
+      }
+
+      self.emit(event.type, event, resources);
+      // If appropriate, emit instance specific events
+      if (instanceIds.length > 0) {
+        _.each(instanceIds, function (instanceId) {
+          self.emit(
+            util.format('%s-%s', event.type, instanceId),
+            event,
+            resources
+          );
+        });
+      }
     }
-  }
+  }).asCallback(callback);
 };
 
 /**


### PR DESCRIPTION
When a WebSocket connection is made via ari.start, it is often useful to know
when that connection has fully established. This is particularly true when
REST calls have to be made that are application dependent (such as subscribing
for particular event sources), as those calls will fail if a WebSocket connection
is not made.

This patch modifies ari.start such that it returns a Promise that is resolved
on the open callback of the underlying WebSocket library, and is rejected on
any error returned back from the same library.