### PR TITLE
The client will now attempt to reconnect to a dropped WebSocket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2223,6 +2223,14 @@ ARI client failed to load.
 function (err) {}
 ```
 
+#### WebSocketMaxRetries
+
+Client will no longer attempt to reconnect to the WebSocket for the current application(s).
+
+```JavaScript
+function (err) {}
+```
+
 #### ApplicationReplaced
 
 Notification that another WebSocket has taken over for an application.

--- a/dev/README.mustache
+++ b/dev/README.mustache
@@ -187,6 +187,14 @@ function (err) {}
 
 {{{events}}}
 
+#### WebSocketMaxRetries
+
+Client will no longer attempt to reconnect to the WebSocket for the current application(s).
+
+```JavaScript
+function (err) {}
+```
+
 # Examples
 
 Callbacks:

--- a/lib/client.js
+++ b/lib/client.js
@@ -26,6 +26,7 @@ var swagger = require('swagger-client');
 var Promise = require('bluebird');
 
 var _ = require('underscore');
+var backoff = require('backoff-func');
 var _resources = require('./resources.js');
 var _utils = require('./utils.js');
 
@@ -299,8 +300,26 @@ Client.prototype._attachApi = function () {
  */
 Client.prototype.start = function (apps, callback) {
   var self = this;
+  // are we currently processing a WebSocket error?
+  var processingError = false;
 
   return new Promise(function(resolve, reject) {
+
+    // Rewrite resolve/reject functions so they can only be called once and
+    // each disables the other when called.
+    resolve = _.once((function (oldResolve) {
+        return function () {
+          oldResolve();
+          reject = function () {};
+        };
+    })(resolve));
+
+    reject = _.once((function (oldReject) {
+        return function () {
+          oldReject();
+          resolve = function () {};
+        };
+    })(reject));
 
     var applications = (_.isArray(apps)) ? apps.join(',') : apps;
     var wsUrl = util.format(
@@ -311,21 +330,33 @@ Client.prototype.start = function (apps, callback) {
       self._connection.pass
     );
 
-    self._ws = new WebSocket(wsUrl);
+    var retry = backoff.create({
+      delay: 100
+    });
 
-    self._ws.on('open', function () {
-      resolve();
-    });
-    self._ws.on('error', function (err) {
-      reject(err);
-    });
-    self._ws.on('message', processMessage);
-    self._ws.on('close', function () { });
+    connect();
+
+    /**
+     *  Connects to the application via WebSocket.
+     *
+     *  @method connect
+     *  @memberof module:ari-client~Client~start
+     *  @private
+     */
+    function connect () {
+      self._ws = new WebSocket(wsUrl);
+
+      self._ws.on('open', function () {
+        processOpen();
+      });
+      self._ws.on('error', processError);
+      self._ws.on('message', processMessage);
+      self._ws.on('close', processClose);
+    }
 
     /**
      *  Process message received by web socket and emit event.
      *
-     *  @callback clientStartCallback
      *  @method processMessage
      *  @memberof module:ari-client~Client~start
      *  @private
@@ -404,6 +435,82 @@ Client.prototype.start = function (apps, callback) {
         });
       }
     }
+
+    /**
+     *  Process open event.
+     *
+     *  @method processOpen
+     *  @memberof module:ari-client~Client~start
+     *  @private
+     */
+    function processOpen () {
+      processingError = false;
+      // onced, will not be called when an automatic reconnect succeeds.
+      resolve();
+    }
+
+    /**
+     *  Process close event. Attempt to reconnect to web socket with a back off
+     *  to ensure we do not flood the server.
+     *
+     *  @method processClose
+     *  @memberof module:ari-client~Client~start
+     *  @private
+     *  @param {Number} reason - reason code for disconnect
+     *  @param {String} description - reason text for disconnect
+     */
+    function processClose (reason, description) {
+      // was connection closed on purpose?
+      if (self._wsClosed) {
+        self._wsClosed = false;
+
+        return;
+      }
+
+      if (!processingError) {
+        reconnect();
+      }
+    }
+
+    /**
+     *  Process error event.
+     *
+     *  @method processError
+     *  @memberof module:ari-client~Client~start
+     *  @private
+     *  @param {Error} err - error object
+     */
+    function processError (err) {
+      // was connection closed on purpose?
+      if (self._wsClosed) {
+        return;
+      }
+
+      processingError = true;
+
+      reconnect(err);
+    }
+
+    /**
+     *  Attempts to reconnect to the WebSocket using a backoff function.
+     *
+     *  @method reconnect
+     *  @memberof module:ari-client~Client~start
+     *  @private
+     *  @param {Error} err - error object
+     */
+    function reconnect(err) {
+      var scheduled = retry(connect);
+
+      if (!scheduled) {
+        // onced or disabled if initial connection succeeds.
+        reject(new Error('Connecton attempts exceeded WebSocketMaxRetries. ' +
+          err.message));
+
+        self.emit('WebSocketMaxRetries', err);
+      }
+    }
+
   }).asCallback(callback);
 };
 
@@ -415,7 +522,9 @@ Client.prototype.start = function (apps, callback) {
  */
 Client.prototype.stop = function () {
   var self = this;
+
   self._ws.close();
+  self._wsClosed = true;
 };
 
 /**

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,10 +1,15 @@
 {
   "name": "ari-client",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "dependencies": {
+    "backoff-func": {
+      "version": "0.1.2",
+      "from": "backoff-func@*",
+      "resolved": "https://registry.npmjs.org/backoff-func/-/backoff-func-0.1.2.tgz"
+    },
     "bluebird": {
       "version": "2.9.34",
-      "from": "bluebird@*",
+      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
     },
     "node-uuid": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ari-client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "JavaScript client for Asterisk REST Interface.",
   "homepage": "https://github.com/asterisk/node-ari-client",
   "keywords": [
@@ -22,6 +22,7 @@
   "license": "Apache-2.0",
   "author": "Samuel Fortier-Galarneau",
   "dependencies": {
+    "backoff-func": "^0.1.2",
     "bluebird": "^2.9.34",
     "node-uuid": "^1.4.1",
     "swagger-client": "^2.0.26",

--- a/test/client.js
+++ b/test/client.js
@@ -152,6 +152,41 @@ describe('client', function () {
     client.connect(url, user, pass, done);
   });
 
+  it('should auto-reconnect websocket', function (done) {
+    wsserver.reconnect();
+
+    setTimeout(function() {
+      ari.on('PlaybackFinished', function(event, playback) {
+        assert(playback.id === 1);
+
+        done();
+      });
+
+      wsserver.send({
+        type: 'PlaybackFinished',
+        playback: {
+          id: 1
+        }
+      });
+    }, 1000);
+  });
+
+  it('should not auto-reconnect websocket after calling stop', function (done) {
+    ari.stop();
+
+    setTimeout(function() {
+      try {
+        wsserver.send({
+          type: 'PlaybackFinished'
+        });
+      } catch (err) {
+        ari.start('unittests');
+
+        done();
+      }
+    }, 1000);
+  });
+
   it('should connect using promises', function (done) {
     client.connect(url, user, pass).then(function (client) {
       if (client) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -35,9 +35,7 @@ function createWebSocketServer (httpserver) {
   var server = new ws.Server({server: httpserver});
   var socket = null;
 
-  server.on('connection', function (websocket) {
-    socket = websocket;
-  });
+  server.on('connection', processConnection);
 
   /**
    *  Web socket server with a send method that will send a message to a
@@ -48,12 +46,39 @@ function createWebSocketServer (httpserver) {
    *  @property {Function} send - send a message to the listening socket
    */
   return {
+    /**
+     *  Sends the json message to the currently connected socket.
+     *
+     *  @param {Object} msg - the json message to send
+     */
     send: function (msg) {
       if (socket) {
         socket.send(JSON.stringify(msg));
       }
+    },
+
+    /**
+     *  Disconnects the server and reconnects.
+     *
+     *  This is intended to test client auto-reconnect.
+     */
+    reconnect: function() {
+      server.close(function() {
+        server = new ws.Server({server: httpserver});
+        server.on('connection', processConnection);
+      });
     }
   };
+
+  /**
+   *  Store the incoming websocket for future use.
+   *
+   *  @param {WebSocket} socket - socket for the last connection
+   */
+  function processConnection(websocket) {
+    socket = websocket;
+  }
+
 }
 
 /**


### PR DESCRIPTION
If a WebSocket is dropped for a reason other than a user stopping an ARI
application, the client will attempt to reconnect to the WebSocket using
an exponential backoff.