### PR TITLE
lib/client.js: Add an option to the 'start' API call to subscribe to all events

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -303,6 +303,12 @@ Client.prototype.start = function (apps, subscribeAll, callback) {
   // are we currently processing a WebSocket error?
   var processingError = false;
 
+  // Perform argument renaming for backwards compatibility
+  if (typeof subscribeAll === 'function') {
+    callback = subscribeAll;
+    subscribeAll = null;
+  }
+
   return new Promise(function(resolve, reject) {
 
     // Rewrite resolve/reject functions so they can only be called once and

--- a/lib/client.js
+++ b/lib/client.js
@@ -298,7 +298,7 @@ Client.prototype._attachApi = function () {
  *  @memberof Client
  *  @method start
  */
-Client.prototype.start = function (apps, callback) {
+Client.prototype.start = function (apps, subscribeAll, callback) {
   var self = this;
   // are we currently processing a WebSocket error?
   var processingError = false;
@@ -329,6 +329,10 @@ Client.prototype.start = function (apps, callback) {
       self._connection.user,
       self._connection.pass
     );
+
+    if (subscribeAll) {
+        wsUrl += '&subscribeAll=true';
+    }
 
     var retry = backoff.create({
       delay: 100


### PR DESCRIPTION
A proposed patch to Asterisk (which would be released in 13.6.0) adds the
ability for a WebSocket connection to suscribe to all event sources in Asterisk
on connection. This patch adds support for that by adding a new option to the
'start' method. If true, the client will pass this along in its initial URI
used to establish the WebSocket, resulting in the application being subscribed
to all event sources.