### PR TITLE
Cleanup jshint usage and move out of Grunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 doc/
 coverage/
 .idea/
+*.log

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -13,6 +13,7 @@
   "node": true,
   "quotmark": true,
   "camelcase": true,
+  "strict": true,
   "maxlen": 80,
   "globals": {
     "Promise" : true

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ examples
 test
 Gruntfile.js
 .jshint
+*.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,20 +9,12 @@
  *  @author Samuel Fortier-Galarneau <sgalarneau@digium.com>
  */
 
-/*global module:false*/
+'use strict';
 
 module.exports = function(grunt) {
 
   // Project configuration.
   grunt.initConfig({
-    // Task configuration.
-    jshint: {
-      options: {
-        jshintrc: true
-      },
-      all: ['Gruntfile.js', 'lib/**/*.js', 'test/**/*.js', 'examples/**/*.js']
-    },
-
     mochaTest: {
       test: {
         options: {
@@ -67,12 +59,11 @@ module.exports = function(grunt) {
   });
 
   // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks('grunt-jsdoc');
 
   // Default task.
-  grunt.registerTask('default', ['jshint', 'mochaTest']);
+  grunt.registerTask('default', ['mochaTest']);
 
   grunt.registerTask(
       'gendocs',

--- a/README.md
+++ b/README.md
@@ -3240,7 +3240,7 @@ client.connect('http://localhost:8088', 'user', 'secret')
 To run the mocha tests for ari-client, run the following:
 
 ```bash
-grunt mochaTest
+npm test
 ```
 
 The tests run against a mocked ARI REST endpoint and websocket server.
@@ -3257,7 +3257,7 @@ npm link
 Then run the following to run jshint and mocha tests:
 
 ```bash
-grunt
+npm test
 ```
 
 jshint will enforce a minimal style guide. It is also a good idea to create unit tests when adding new features to ari-client.

--- a/examples/bridge.js
+++ b/examples/bridge.js
@@ -15,9 +15,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*jshint globalstrict: true*/
-
 var client = require('ari-client');
 
 client.connect('http://ari.js:8088', 'user', 'secret',

--- a/examples/device_state.js
+++ b/examples/device_state.js
@@ -16,9 +16,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*jshint globalstrict: true*/
-
 var client = require('ari-client');
 var util = require('util');
 

--- a/examples/example.js
+++ b/examples/example.js
@@ -15,10 +15,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*global process:false*/
-/*jshint globalstrict: true*/
-
 var client = require('ari-client');
 var util = require('util');
 

--- a/examples/mwi.js
+++ b/examples/mwi.js
@@ -15,9 +15,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*jshint globalstrict: true*/
-
 var client = require('ari-client');
 var util = require('util');
 

--- a/examples/originate.js
+++ b/examples/originate.js
@@ -16,9 +16,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*jshint globalstrict: true*/
-
 var client = require('ari-client');
 
 var ENDPOINT = 'SIP/sipphone';

--- a/examples/playback.js
+++ b/examples/playback.js
@@ -15,11 +15,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*global process:false*/
-/*global console:false*/
-/*jshint globalstrict: true*/
-
 var client = require('ari-client');
 var util = require('util');
 

--- a/examples/promises/bridge.js
+++ b/examples/promises/bridge.js
@@ -15,9 +15,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*jshint globalstrict: true*/
-
 var client = require('ari-client');
 
 client.connect('http://ari.js:8088', 'user', 'secret')

--- a/examples/promises/device_state.js
+++ b/examples/promises/device_state.js
@@ -16,9 +16,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*jshint globalstrict: true*/
-
 var client = require('ari-client');
 var util = require('util');
 

--- a/examples/promises/example.js
+++ b/examples/promises/example.js
@@ -15,10 +15,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*global process:false*/
-/*jshint globalstrict: true*/
-
 var client = require('ari-client');
 var Promise = require('bluebird');
 var util = require('util');

--- a/examples/promises/mwi.js
+++ b/examples/promises/mwi.js
@@ -15,9 +15,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*jshint globalstrict: true*/
-
 var client = require('ari-client');
 var Promise = require('bluebird');
 var util = require('util');

--- a/examples/promises/originate.js
+++ b/examples/promises/originate.js
@@ -16,9 +16,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*jshint globalstrict: true*/
-
 var client = require('ari-client');
 
 var ENDPOINT = 'SIP/sipphone';

--- a/examples/promises/playback.js
+++ b/examples/promises/playback.js
@@ -15,11 +15,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*global process:false*/
-/*global console:false*/
-/*jshint globalstrict: true*/
-
 var client = require('ari-client');
 var util = require('util');
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -13,10 +13,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*global module:false*/
-/*jshint globalstrict: true*/
-
 var util = require('util');
 var url = require('url');
 var events = require('events');

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -11,10 +11,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*global module:false*/
-/*jshint globalstrict: true*/
-
 var util = require('util');
 
 var _ = require('underscore');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,10 +10,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*global module:false*/
-/*jshint globalstrict: true*/
-
 var _ = require('underscore');
 
 /**

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   ],
   "main": "./lib/client.js",
   "scripts": {
-    "test": "mocha --reporter spec",
+    "test": "npm run lint && mocha --reporter spec",
     "cover": "istanbul cover --report html _mocha",
-    "check-coverage": "npm run cover && istanbul check-coverage --lines 75 --statements 75 --functions 75 --branches 70"
+    "check-coverage": "npm run cover && istanbul check-coverage --lines 75 --statements 75 --functions 75 --branches 70",
+    "lint": "jshint . --verbose"
   },
   "repository": {
     "type": "git",
@@ -37,11 +38,11 @@
   "devDependencies": {
     "async": "^0.8.0",
     "grunt": "^0.4.4",
-    "grunt-contrib-jshint": "^0.10.0",
     "grunt-jsdoc": "^0.5.4",
     "grunt-mocha-test": "^0.10.0",
     "hock": "^0.2.5",
     "istanbul": "^0.4.4",
+    "jshint": "^2.9.2",
     "mocha": "^1.17.1",
     "moment": "^2.6.0",
     "mustache": "^0.8.1",

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "extends": "../.jshintrc",
+  "mocha": true
+}

--- a/test/client.js
+++ b/test/client.js
@@ -9,19 +9,10 @@
 
 'use strict';
 
-/*global describe:false*/
-/*global before:false*/
-/*global after:false*/
-/*global it:false*/
-/*global require:false*/
-/*jshint globalstrict: true*/
-
 var util = require('util');
 var assert = require('assert');
-
 var _ = require('underscore');
 var Promise = require('bluebird');
-
 var client = require('../lib/client.js');
 var helpers = require('./helpers.js');
 
@@ -209,7 +200,7 @@ describe('client', function () {
       if (err) { return done(err); }
 
       function doItAgain() {
-        if (reconnectCount-- == 0) {
+        if (reconnectCount-- === 0) {
           done();
           return;
         }

--- a/test/events.js
+++ b/test/events.js
@@ -10,14 +10,6 @@
 
 'use strict';
 
-/*global describe:false*/
-/*global before:false*/
-/*global after:false*/
-/*global it:false*/
-/*global setTimeout:false*/
-/*global require:false*/
-/*jshint globalstrict: true*/
-
 var client = require('../lib/client.js');
 var _ = require('underscore');
 var util = require('util');

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,12 +9,6 @@
 
 'use strict';
 
-/*global require:false*/
-/*global module:false*/
-/*global console:false*/
-/*global __dirname:false*/
-/*jshint globalstrict: true*/
-
 var hock = require('hock');
 var fs = require('fs');
 var util = require('util');


### PR DESCRIPTION
Previously there were a lot of jshint directives as comments througout
the codebase that were unnecessary. This patch cleans up the use of
jshint, and moves it out of Grunt and to an npm script.