### PR TITLE
Remove mocha from grunt

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,17 +15,6 @@ module.exports = function(grunt) {
 
   // Project configuration.
   grunt.initConfig({
-    mochaTest: {
-      test: {
-        options: {
-          mocha: require('mocha'),
-          reporter: 'spec',
-          timeout: 2000
-        },
-        src: ['test/*.js']
-      }
-    },
-
     gendocs: {
       options: {
         baseUrl: 'http://ari.js:8088',
@@ -59,11 +48,10 @@ module.exports = function(grunt) {
   });
 
   // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks('grunt-jsdoc');
 
   // Default task.
-  grunt.registerTask('default', ['mochaTest']);
+  grunt.registerTask('default', ['gendocs']);
 
   grunt.registerTask(
       'gendocs',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "main": "./lib/client.js",
   "scripts": {
-    "test": "npm run lint && mocha --reporter spec",
+    "test": "npm run lint && mocha",
     "cover": "istanbul cover --report html _mocha",
     "check-coverage": "npm run cover && istanbul check-coverage --lines 75 --statements 75 --functions 75 --branches 70",
     "lint": "jshint . --verbose"
@@ -38,9 +38,11 @@
   "devDependencies": {
     "async": "^2.0.1",
     "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
     "grunt-jsdoc": "^2.1.0",
     "grunt-mocha-test": "^0.12.7",
     "hock": "^1.3.1",
+    "env-test": "^1.0.0",
     "istanbul": "^0.4.4",
     "jshint": "^2.9.2",
     "mocha": "^3.0.2",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,5 @@
+--timeout 2000
+--reporter spec
+--require env-test
+--recursive
+--full-trace


### PR DESCRIPTION
This patch removes mocha from grunt, cleans up the npm script, and
adds a mocha.opts file to set default options.

Tests should now be run with just `npm test`.