### PR TITLE
Update dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,17 +36,17 @@
     "node": ">=4"
   },
   "devDependencies": {
-    "async": "^0.8.0",
-    "grunt": "^0.4.4",
-    "grunt-jsdoc": "^0.5.4",
-    "grunt-mocha-test": "^0.10.0",
-    "hock": "^0.2.5",
+    "async": "^2.0.1",
+    "grunt": "^1.0.1",
+    "grunt-jsdoc": "^2.1.0",
+    "grunt-mocha-test": "^0.12.7",
+    "hock": "^1.3.1",
     "istanbul": "^0.4.4",
     "jshint": "^2.9.2",
-    "mocha": "^1.17.1",
+    "mocha": "^3.0.2",
     "moment": "^2.6.0",
-    "mustache": "^0.8.1",
-    "portfinder": "^0.4.0",
+    "mustache": "^2.2.1",
+    "portfinder": "^1.0.6",
     "request": "^2.34.0"
   }
 }

--- a/test/events.js
+++ b/test/events.js
@@ -13,6 +13,8 @@
 var client = require('../lib/client.js');
 var _ = require('underscore');
 var util = require('util');
+var portfinder = require('portfinder');
+var http = require('http');
 var assert = require('assert');
 var helpers = require('./helpers.js');
 
@@ -26,27 +28,30 @@ describe('events', function () {
   var wsserver = null;
 
   before(function (done) {
-    helpers.mockClient(function (err, hockServer, port) {
-      server = hockServer;
-      url = util.format(url, port);
-      client.connect(url, user, pass, clientLoaded);
+    portfinder.getPort(function (err, port) {
+      assert.ifError(err);
 
-      function clientLoaded (err, newClient) {
-        ari = newClient;
-        wsserver = helpers.createWebSocketServer(server._server);
-        ari.start('unittests');
+      server = helpers.buildMockServer(port);
+      server.realServer = http.createServer(server.handler);
+      server.realServer.listen(port, function () {
+        url = util.format(url, port);
+        client.connect(url, user, pass, function (err, connectedClient) {
+          ari = connectedClient;
+          wsserver = helpers.createWebSocketServer(server.realServer);
+          ari.start('unittests');
 
-        // ensure socket is connected before tests start
-        setTimeout(function () {
-          done();
-        }, 1000);
-      }
+          // ensure socket is connected before tests start
+          setTimeout(function () {
+            done();
+          }, 1000);
+        });
+      });
     });
   });
 
   after(function (done) {
     ari.stop();
-    server.close(done);
+    server.realServer.close(done);
   });
 
   describe('#client', function () {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -76,141 +76,120 @@ function createWebSocketServer (httpserver) {
 }
 
 /**
- *  Sets up a hock API mock on an open port to support running
- *  ari-hockServer.connect.
- *
- *  @function mockClient
- *  @memberof module:tests-helpers
- *  @param {Function} callback - invoked with hock server and port once
- *                               mocking complete
- */
-function mockClient(callback) {
-  portfinder.getPort(function(err, port) {
-    if (err) {
-      throw err;
-    }
-
-    buildMockClient(port, callback);
-  });
-}
-
-/**
  *  Sets up a hock API mock to support running ari-hockServer.connect.
  *
  *  @function mockClient
  *  @memberof module:tests-helpers
- *  @param {integer} port - the port to run the server on
- *  @param {Function} callback - invoked with hock server and port once
- *                               mocking complete
+ *  @param {number} port the port to run the server on
+ *  @returns The hock mock server
  */
-function buildMockClient (port, callback) {
-  hock.createHock(port, function (err, hockServer) {
-    // setup resources URI
-    var body = readJsonFixture('resources', port);
-    var headers = getJsonHeaders(body);
-    hockServer
+function buildMockServer(port) {
+  var hockServer = hock.createHock();
+
+  var body = readJsonFixture('resources', port);
+  var headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/resources.json')
       .any()
       .reply(200, body, headers);
 
-    // setup recordings URI
-    body = readJsonFixture('recordings', port);
-    headers = getJsonHeaders(body);
-    hockServer
+  // setup recordings URI
+  body = readJsonFixture('recordings', port);
+  headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/recordings.json')
       .any()
       .reply(200, body, headers);
 
-    // setup bridges URI
-    body = readJsonFixture('bridges', port);
-    headers = getJsonHeaders(body);
-    hockServer
+  // setup bridges URI
+  body = readJsonFixture('bridges', port);
+  headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/bridges.json')
       .any()
       .reply(200, body, headers);
 
-    // setup endpoints URI
-    body = readJsonFixture('endpoints', port);
-    headers = getJsonHeaders(body);
-    hockServer
+  // setup endpoints URI
+  body = readJsonFixture('endpoints', port);
+  headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/endpoints.json')
       .any()
       .reply(200, body, headers);
 
-    // setup asterisk URI
-    body = readJsonFixture('asterisk', port);
-    headers = getJsonHeaders(body);
-    hockServer
+  // setup asterisk URI
+  body = readJsonFixture('asterisk', port);
+  headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/asterisk.json')
       .any()
       .reply(200, body, headers);
 
-    // setup sounds URI
-    body = readJsonFixture('sounds', port);
-    headers = getJsonHeaders(body);
-    hockServer
+  // setup sounds URI
+  body = readJsonFixture('sounds', port);
+  headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/sounds.json')
       .any()
       .reply(200, body, headers);
 
-    // setup channels URI
-    body = readJsonFixture('channels', port);
-    headers = getJsonHeaders(body);
-    hockServer
+  // setup channels URI
+  body = readJsonFixture('channels', port);
+  headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/channels.json')
       .any()
       .reply(200, body, headers);
 
-    // setup playbacks URI
-    body = readJsonFixture('playbacks', port);
-    headers = getJsonHeaders(body);
-    hockServer
+  // setup playbacks URI
+  body = readJsonFixture('playbacks', port);
+  headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/playbacks.json')
       .any()
       .reply(200, body, headers);
 
-    // setup deviceStates URI
-    body = readJsonFixture('deviceStates', port);
-    headers = getJsonHeaders(body);
-    hockServer
+  // setup deviceStates URI
+  body = readJsonFixture('deviceStates', port);
+  headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/deviceStates.json')
       .any()
       .reply(200, body, headers);
 
-    // setup mailboxes URI
-    body = readJsonFixture('mailboxes', port);
-    headers = getJsonHeaders(body);
-    hockServer
+  // setup mailboxes URI
+  body = readJsonFixture('mailboxes', port);
+  headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/mailboxes.json')
       .any()
       .reply(200, body, headers);
 
-    // setup applications URI
-    body = readJsonFixture('asterisk');
-    headers = getJsonHeaders(body);
-    hockServer
+  // setup applications URI
+  body = readJsonFixture('asterisk');
+  headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/asterisk.json')
       .any()
       .reply(200, body, headers);
 
-    // setup applications URI
-    body = readJsonFixture('applications', port);
-    headers = getJsonHeaders(body);
-    hockServer
+  // setup applications URI
+  body = readJsonFixture('applications', port);
+  headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/applications.json')
       .any()
       .reply(200, body, headers);
 
-    // setup events URI
-    body = readJsonFixture('events', port);
-    headers = getJsonHeaders(body);
-    hockServer
+  // setup events URI
+  body = readJsonFixture('events', port);
+  headers = getJsonHeaders(body);
+  hockServer
       .get('/ari/api-docs/events.json')
       .any()
       .reply(200, body, headers);
 
-    callback(err, hockServer, port);
-  });
+  return hockServer;
 }
 
 /**
@@ -253,7 +232,7 @@ function getJsonHeaders (json) {
   };
 }
 
-module.exports.mockClient = mockClient;
+module.exports.buildMockServer = buildMockServer;
 module.exports.getJsonHeaders = getJsonHeaders;
 module.exports.createWebSocketServer = createWebSocketServer;
 


### PR DESCRIPTION
This patch updates all outdated development dependencies, but does
**not** upgrade the two outdated production dependencies.

- swagger-client, which is currently pinned at 2.1.17 due to a
breaking change that is difficult to address (see #47 for details).

- bluebird, which currently has a major version upgrade available
that includes breaking changes. See
http://bluebirdjs.com/docs/new-in-bluebird-3.html for details.
These are workable changes for node-ari-client, but we expose
bluebird Promises on our public API, so updating this would require
a major version bump.

For changes in the development dependencies, see the following
changelog entries:

- grunt: http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released
- async: https://github.com/caolan/async/blob/master/CHANGELOG.md
- mocha: https://github.com/mochajs/mocha/blob/master/CHANGELOG.md
- mustache: https://github.com/janl/mustache.js/blob/master/CHANGELOG.md
- portfinder: https://github.com/indexzero/node-portfinder/pull/20

No details regarding the major version bump of hock could be found,
but it had a substantial change to its public api. Namely, it does not
handle any of the actual http server stuff for you anymore. Changes
are included in this PR to adapt the tests to this new api.

There are still some npm install warnings even after updating these
dependencies:

- jshint is throwing a warning about minimatch needing an upgrade.
The fix for this is already in the jshint master branch, but no
npm version has been cut for it yet. For additional details, see
https://github.com/jshint/jshint/issues/2952

- jsdoc is throwing warnings about minimatch needing an upgrade,
wrench being completely deprecated in favor of another library,
and the marked package not being meant to be installed as a dep.
Upon investigation, it seems that the jsdoc package has actually
been abandoned, so we need to start thinking about migrating away
from it. Ticket #55 has been opened to investigate this.

- grunt has a warning about coffee-script not being meant to be
installed as a dep. This isn't really worth looking into, as we
are gradually moving away from grunt anyway.