### PR TITLE
Add url-encoding for websocket string

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -335,8 +335,8 @@ Client.prototype.start = function (apps, subscribeAll, callback) {
       (self._connection.protocol === 'https:' ? 'wss' : 'ws'),
       self._connection.host,
       applications,
-      self._connection.user,
-      self._connection.pass
+      encodeURIComponent(self._connection.user),
+      encodeURIComponent(self._connection.pass)
     );
 
     if (subscribeAll) {


### PR DESCRIPTION
Hi, here's the url-encoding bit for the issue #76. 

(Test - pending. <sub>Read: I don't know how to add a test for this case, sorry.</sub>)