### PR TITLE
Fix error being swallowed up

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -315,19 +315,9 @@ Client.prototype.start = function (apps, subscribeAll, callback) {
 
     // Rewrite resolve/reject functions so they can only be called once and
     // each disables the other when called.
-    resolve = _.once((function (oldResolve) {
-      return function () {
-        oldResolve();
-        reject = function () {};
-      };
-    })(resolve));
+    resolve = _.once(resolve);
 
-    reject = _.once((function (oldReject) {
-      return function () {
-        oldReject();
-        resolve = function () {};
-      };
-    })(reject));
+    reject = _.once(reject);
 
     var applications = (_.isArray(apps)) ? apps.join(',') : apps;
     var wsUrl = util.format(


### PR DESCRIPTION
Also for #76 . The mysteriously vanishing error was being swallowed up by this code:

    reject = _.once((function (oldReject) {
        return function () {
          oldReject();
          resolve = function () {};
        };
    })(reject));

All it needed was the error parameter:

    reject = _.once((function (oldReject) {
        return function(err) {
            oldReject(err);
            ...

However, Underscore's `_.once` handles this for us already, so I just changed it to

     reject = _.once(reject);