### PR TITLE
Add ping event and add emit method for pong

### DIFF
--- a/README.md
+++ b/README.md
@@ -3199,14 +3199,6 @@ Client will no longer attempt to reconnect to the WebSocket for the current appl
 function (err) {}
 ```
 
-##### pong
-
-Client received pong event (to be used with the `ping()` method)
-
-```Javascript
-function () {}
-```
-
 # Examples
 
 Callbacks:

--- a/README.md
+++ b/README.md
@@ -3199,6 +3199,14 @@ Client will no longer attempt to reconnect to the WebSocket for the current appl
 function (err) {}
 ```
 
+##### pong
+
+Client received pong event (to be used with the `ping()` method)
+
+```Javascript
+function () {}
+```
+
 # Examples
 
 Callbacks:

--- a/lib/client.js
+++ b/lib/client.js
@@ -354,7 +354,19 @@ Client.prototype.start = function (apps, subscribeAll, callback) {
       });
       self._ws.on('error', processError);
       self._ws.on('message', processMessage);
+      self._ws.on('pong', processPong);
       self._ws.on('close', processClose);
+    }
+
+    /**
+     * Process pong received by web socket and emit event
+     *
+     * @method processPing
+     * @memberof module:ari-client~Client~start
+     * @private
+     */
+    function processPong () {
+      self.emit('pong');
     }
 
     /**
@@ -536,6 +548,21 @@ Client.prototype.stop = function () {
 
   self._ws.close();
   self._wsClosed = true;
+};
+
+/**
+ *  Pings the web socket
+ *
+ *  @memberof Client
+ *  @method ping
+ */
+Client.prototype.ping = function () {
+  var self = this;
+
+  if (self._ws === undefined || self._wsClosed) {
+    return;
+  }
+  self._ws.ping();
 };
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -359,11 +359,11 @@ Client.prototype.start = function (apps, subscribeAll, callback) {
     }
 
     /**
-     * Process pong received by web socket and emit event
+     *  Process pong received by web socket and emit event
      *
-     * @method processPing
-     * @memberof module:ari-client~Client~start
-     * @private
+     *  @method processPing
+     *  @memberof module:ari-client~Client~start
+     *  @private
      */
     function processPong () {
       self.emit('pong');


### PR DESCRIPTION
To avoid half open socket connections, for instance when connecting to Asterisk over VPN, add a ``client.ping()`` method and emit the ``pong`` event when received.

Fixes #104