### PR TITLE
support optional path prefix in asterisk http.conf

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -61,7 +61,7 @@ function Client(baseUrl, user, pass) {
     host: parsedUrl.host,
     hostname: parsedUrl.hostname,
     // support optional path prefix in asterisk http.conf
-    prefix: parsedUrl.pathname == '/' ? '' : parsedUrl.pathname,
+    prefix: parsedUrl.pathname === '/' ? '' : parsedUrl.pathname,
     user: user,
     pass: pass
   };
@@ -108,7 +108,7 @@ Client.prototype._attachApi = function () {
       '%s//%s%s/ari/api-docs/resources.json',
       self._connection.protocol,
       self._connection.host,
-      self._connection.prefix,
+      self._connection.prefix
     );
 
     request(ariUrl, function (err) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -60,6 +60,8 @@ function Client(baseUrl, user, pass) {
     protocol: parsedUrl.protocol,
     host: parsedUrl.host,
     hostname: parsedUrl.hostname,
+    // support optional path prefix in asterisk http.conf
+    prefix: parsedUrl.pathname == '/' ? '' : parsedUrl.pathname,
     user: user,
     pass: pass
   };
@@ -103,9 +105,10 @@ Client.prototype._attachApi = function () {
 
     // Connect to API using swagger and attach resources on Client instance
     var ariUrl = util.format(
-      '%s//%s/ari/api-docs/resources.json',
+      '%s//%s%s/ari/api-docs/resources.json',
       self._connection.protocol,
-      self._connection.host
+      self._connection.host,
+      self._connection.prefix,
     );
 
     request(ariUrl, function (err) {
@@ -332,9 +335,10 @@ Client.prototype.start = function (apps, subscribeAll, callback) {
 
     var applications = (_.isArray(apps)) ? apps.join(',') : apps;
     var wsUrl = util.format(
-      '%s://%s/ari/events?app=%s&api_key=%s:%s',
+      '%s://%s%s/ari/events?app=%s&api_key=%s:%s',
       (self._connection.protocol === 'https:' ? 'wss' : 'ws'),
       self._connection.host,
+      self._connection.prefix,
       applications,
       encodeURIComponent(self._connection.user),
       encodeURIComponent(self._connection.pass)


### PR DESCRIPTION
This change is to support communication with asterisk systems configured with a prefix in in [http.conf](https://github.com/asterisk/asterisk/blob/0de74fad5597ba12ec68bcc935330a612ee255d6/configs/samples/http.conf.sample#L45)
