### PR TITLE
Cleanup object dumps for concise logging

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -51,7 +51,10 @@ var swaggerListTypeRegex = /List\[([A-Za-z]+)\]/;
 function Resource (client, id, objValues) {
   var self = this;
 
-  self._client = client;
+  Object.defineProperty(self, '_client', {
+      value: client
+  });
+
   // id is optional
   if (!objValues) {
     objValues = id;


### PR DESCRIPTION
This simple change sets the ARI _client on the resource to not be enumerable.
What that means is that it won't print it (I checked the code for other use cases that involve iterating through properties and didn't see an issue).

Harmless change that makes dev much easier.