### PR TITLE
Fix getStoredFile() fails

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -958,9 +958,15 @@ function attachOperations () {
          *  @param {Object} response - response from swagger
          */
         function processResponse (response) {
-          var result = response.data.toString('utf-8');
-          if (respType !== null && result) {
-            result = JSON.parse(result);
+          var result;
+
+          if (respType === 'binary') {
+            result = Buffer.from(response.data);
+          } else {
+            result = response.data.toString('utf-8');
+            if (respType !== null && result) {
+              result = JSON.parse(result);
+            }
           }
 
           if (_.includes(knownTypes, respType) &&


### PR DESCRIPTION
Same fix as #64 for issue #62.