### PR TITLE
feat: expose reconnection retries

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -485,7 +485,9 @@ Client.prototype.start = function (apps, subscribeAll, callback) {
       processingError = false;
       // reset backoff handler when we successfully connect
       retry = backoff.create({
-        delay: 100
+        delay: self._connection.options.retryDelay || 100,
+        maxDelay: self._connection.options.retryMaxDelay,
+        maxRetries: self._connection.options.maxRetries,
       });
       self.emit('WebSocketConnected');
       // onced, will not be called when an automatic reconnect succeeds.

--- a/lib/client.js
+++ b/lib/client.js
@@ -355,7 +355,7 @@ Client.prototype.start = function (apps, subscribeAll, callback) {
 
     var retry = backoff.create({
       delay: self._connection.options.retryDelay || 100,
-      maxDelay: self._connection.options.maxDelay,
+      maxDelay: self._connection.options.retryMaxDelay,
       maxRetries: self._connection.options.maxRetries,
     });
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -601,7 +601,7 @@ Client.prototype.ping = function () {
  *    The callback to be called upon connection
  *  @returns {Q} promise - a promise that will resolve to a client
  */
-module.exports.connect = function (baseUrl, user, pass,
+module.exports.connect = function (baseUrl, user, pass, options,
     /**
      *  @callback connectCallback
      *  @memberof module:ari-client
@@ -610,7 +610,7 @@ module.exports.connect = function (baseUrl, user, pass,
      */
     callback) {
 
-  var client = new Client(baseUrl, user, pass);
+  var client = new Client(baseUrl, user, pass, options);
   client.setMaxListeners(0);
 
   return client._attachApi().asCallback(callback);

--- a/lib/client.js
+++ b/lib/client.js
@@ -40,7 +40,7 @@ var _utils = require('./utils.js');
  *  @prop {Object} _instanceListeners - array of instance objects for
  *    instances that registered for scoped events keyed by event type
  */
-function Client(baseUrl, user, pass) {
+function Client(baseUrl, user, pass, options) {
   var self = this;
   events.EventEmitter.call(self);
 
@@ -55,6 +55,10 @@ function Client(baseUrl, user, pass) {
    * @prop {string} hostname
    * @prop {string} user - username for ARI instance
    * @prop {string} pass - password for ARI instance
+   * @prop {Object} options - options for ARI instance
+   * @prop {number} options.maxRetries - maximum number of retries
+   * @prop {number} options.retryDelay - delay between retries
+   * @prop {number} options.retryMaxDelay - maximum delay between retries
    */
   self._connection = {
     protocol: parsedUrl.protocol,
@@ -63,7 +67,8 @@ function Client(baseUrl, user, pass) {
     // support optional path prefix in asterisk http.conf
     prefix: parsedUrl.pathname === '/' ? '' : parsedUrl.pathname,
     user: user,
-    pass: pass
+    pass: pass,
+    options: options || {}
   };
 
   // Keep track of instance event listeners. once true means that the callback
@@ -349,7 +354,9 @@ Client.prototype.start = function (apps, subscribeAll, callback) {
     }
 
     var retry = backoff.create({
-      delay: 100
+      delay: self._connection.options.retryDelay || 100,
+      maxDelay: self._connection.options.maxDelay,
+      maxRetries: self._connection.options.maxRetries,
     });
 
     connect();


### PR DESCRIPTION
This PR is created to expose re-connection  options because whenever asterisk is stopped and started the WebSocketMaxRetries is reached too quickly (within a minute).

after this PR it will be possible for devs to specify their preferred configuration like this 

`this.ari = await ariClient.connect(Host, Username, Password, {
				maxRetries: 1000,
				retryDelay: 100,
				retryMaxDelay: 1000 * 60 * 5
			});`